### PR TITLE
Patch 1

### DIFF
--- a/client/client.php
+++ b/client/client.php
@@ -131,7 +131,7 @@ class Client {
         }
 
         // return error response
-        if ($response->error) {
+        if (property_exists($response, 'error')) {
             return new Response(null, $response->id, $response->error->code, $response->error->message);
         }
 

--- a/client/request.php
+++ b/client/request.php
@@ -21,7 +21,9 @@ class Request {
         // ensure params are utf8
         if ($params !== null) {
             foreach ($params as &$param) {
-                $param = utf8_encode($param);
+                if(is_string($param)){
+                    $param = utf8_encode($param);
+                }
             }
         }
 


### PR DESCRIPTION
Hi,

I've committed two small changes to the client.
1. bc71e871: Accessing the response error was giving a notice. Changed it to check if the property exists instead.
2. 94160de8: Data types like integers would get turned into strings before being sent to the server because they were being unnecessarily UTF8 encoded.

Thanks,
Ben
