### PR TITLE
Prevent PHP Warning from happening when you pass less than the required number of arguments to an RPC function.

### DIFF
--- a/lib/Junior/Server.php
+++ b/lib/Junior/Server.php
@@ -45,6 +45,16 @@ class Server {
         }
         $reflection = new \ReflectionMethod($this->exposed_instance, $method);
         
+        // Prevent calls to abstract functions
+        if ($reflection->isAbstract()) {
+            throw new Serverside\Exception("Method is abstract and therefore not callable.");
+        }
+        
+        // Only allow calls to public functions
+        if (!$reflection->isPublic()) {
+            throw new Serverside\Exception("Called method is not publically accessible.");
+        }
+        
         $num_required_params = $reflection->getNumberOfRequiredParameters();
         if ($num_required_params > count($params)) {
             throw new Serverside\Exception("Too less parameters passed.");

--- a/lib/Junior/Server.php
+++ b/lib/Junior/Server.php
@@ -44,6 +44,12 @@ class Server {
             $params = array();
         }
         $reflection = new \ReflectionMethod($this->exposed_instance, $method);
+        
+        $num_required_params = $reflection->getNumberOfRequiredParameters();
+        if ($num_required_params > count($params)) {
+            throw new Serverside\Exception("Too less parameters passed.");
+        }
+        
         return $reflection->invokeArgs($this->exposed_instance, $params);
     }
 


### PR DESCRIPTION
Hi EvilScott,

thank you for this nice piece of software!!!

we have a PHP configuration that turns every warning into an error. So when you call an RPC method with less than the required parameters I get an error. From my point of view, we can utilize the reflection mechanisms just as I did and check if one specified enough parameters.

Please have a look at my small commit (4 lines of code) and pull it into your repository.

Thank you in advance!

-Konrad
