### PR TITLE
HTTP Digest and HTTP Basic authentication

### DIFF
--- a/lib/Junior.php
+++ b/lib/Junior.php
@@ -2,3 +2,7 @@
 set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__);
 require_once('Junior' . DIRECTORY_SEPARATOR . 'Client.php');
 require_once('Junior' . DIRECTORY_SEPARATOR . 'Server.php');
+if (function_exists('curl_init')) {
+    require_once('Junior' . DIRECTORY_SEPARATOR . 'ClientBasicAuth.php');
+    require_once('Junior' . DIRECTORY_SEPARATOR . 'ClientDigestAuth.php');
+}

--- a/lib/Junior/ClientBasicAuth.php
+++ b/lib/Junior/ClientBasicAuth.php
@@ -49,7 +49,7 @@ class ClientBasicAuth extends Client {
         curl_setopt($ch, CURLOPT_UNRESTRICTED_AUTH, true);
         // Apply the curl authentication options
         curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-        curl_setopt($ch, CURLOPT_USERPWD, "{$this->curlUsername}:{$this->curlPassword}");
+        curl_setopt($ch, CURLOPT_USERPWD, "{$this->username}:{$this->password}");
         curl_setopt($ch, CURLOPT_POSTFIELDS, $json);
         $response = curl_exec($ch);
         curl_close($ch);

--- a/lib/Junior/ClientBasicAuth.php
+++ b/lib/Junior/ClientBasicAuth.php
@@ -1,0 +1,73 @@
+<?php
+namespace Junior;
+use Junior\Clientside\Exception,
+    Junior\Client;
+
+require_once('Junior'. DIRECTORY_SEPARATOR . 'Client.php');
+
+/**
+ * This class basically does the same thing as the \c Junior\Client class except
+ * that it can handle HTTP Basic Authentication.
+ *
+ * @FIXME Remove dependency on curl to support PHP installation that don't have it.
+ * @TODO Add tests for this class
+ *
+ * @author Konrad Kleine (kwk)
+ */
+class ClientBasicAuth extends Client {
+
+    private $username = "";
+    private $password = "";
+    
+    /**
+     * Sets the \a $username and \a $password to be used for the HTTP Basic
+     * authentication and passes the \a $uri to the parent constructor.
+     */
+    public function __construct($uri, $username, $password)
+    {
+        parent::__construct($uri);
+        $this->username = $username;
+        $this->password = $password;
+    }
+
+    /**
+     * @override
+     */
+    public function send($json, $notify = false)
+    {
+        $response = false;
+        
+        $ch = curl_init($this->uri);
+        // Return result as string instead of printing it
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        // HTTP Post
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-type: application/json'));
+        // Follow any "Location: " header
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        // Keep sending the username and password when following locations
+        curl_setopt($ch, CURLOPT_UNRESTRICTED_AUTH, true);
+        // Apply the curl authentication options
+        curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+        curl_setopt($ch, CURLOPT_USERPWD, "{$this->curlUsername}:{$this->curlPassword}");
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $json);
+        $response = curl_exec($ch);
+        curl_close($ch);
+
+        // handle communication errors
+        if ($response === false) {
+            throw new Clientside\Exception("Unable to connect to {$this->uri}");
+        }
+
+        // notify has no response
+        if ($notify) {
+            return true;
+        }
+
+        // try to decode json
+        $json_response = $this->decodeJSON($response);
+
+        // handle response, create response object and return it
+        return $this->handleResponse($json_response);
+    }
+}

--- a/lib/Junior/ClientDigestAuth.php
+++ b/lib/Junior/ClientDigestAuth.php
@@ -1,0 +1,73 @@
+<?php
+namespace Junior;
+use Junior\Clientside\Exception,
+    Junior\Client;
+
+require_once('Junior'. DIRECTORY_SEPARATOR . 'Client.php');
+
+/**
+ * This class basically does the same thing as the \c Junior\Client class except
+ * that it can handle HTTP Digest Authentication.
+ *
+ * @FIXME Remove dependency on curl to support PHP installation that don't have it.
+ * @TODO Add tests for this class
+ *
+ * @author Konrad Kleine (kwk)
+ */
+class ClientDigestAuth extends Client {
+
+    private $username = "";
+    private $password = "";
+    
+    /**
+     * Sets the \a $username and \a $password to be used for the HTTP Digest
+     * authentication and passes the \a $uri to the parent constructor.
+     */
+    public function __construct($uri, $username, $password)
+    {
+        parent::__construct($uri);
+        $this->username = $username;
+        $this->password = $password;
+    }
+
+    /**
+     * @override
+     */
+    public function send($json, $notify = false)
+    {
+        $response = false;
+        
+        $ch = curl_init($this->uri);
+        // Return result as string instead of printing it
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        // HTTP Post
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-type: application/json'));
+        // Follow any "Location: " header
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        // Keep sending the username and password when following locations
+        curl_setopt($ch, CURLOPT_UNRESTRICTED_AUTH, true);
+        // Apply the curl authentication options
+        curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+        curl_setopt($ch, CURLOPT_USERPWD, "{$this->curlUsername}:{$this->curlPassword}");
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $json);
+        $response = curl_exec($ch);
+        curl_close($ch);
+
+        // handle communication errors
+        if ($response === false) {
+            throw new Clientside\Exception("Unable to connect to {$this->uri}");
+        }
+
+        // notify has no response
+        if ($notify) {
+            return true;
+        }
+
+        // try to decode json
+        $json_response = $this->decodeJSON($response);
+
+        // handle response, create response object and return it
+        return $this->handleResponse($json_response);
+    }
+}

--- a/lib/Junior/ClientDigestAuth.php
+++ b/lib/Junior/ClientDigestAuth.php
@@ -49,7 +49,7 @@ class ClientDigestAuth extends Client {
         curl_setopt($ch, CURLOPT_UNRESTRICTED_AUTH, true);
         // Apply the curl authentication options
         curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
-        curl_setopt($ch, CURLOPT_USERPWD, "{$this->curlUsername}:{$this->curlPassword}");
+        curl_setopt($ch, CURLOPT_USERPWD, "{$this->username}:{$this->password}");
         curl_setopt($ch, CURLOPT_POSTFIELDS, $json);
         $response = curl_exec($ch);
         curl_close($ch);


### PR DESCRIPTION
Hi Scott,

I respect your thoughts on PHP installations that don't have curl and I also respect that you don't want to break your tests that were implemented against stream_context_... functions.

Nevertheless I still have to be able to hide some services behind some form of HTTP authentication. To me the cleanest design choice was to implemented this authentication layer in a sublasses of Junior\Client. Although you don't have any tests for the two new classes Junior\ClientBasicAuth and Junior\ClientDigestAuth I suggest we work on them and try to remove the dependency on curl from them. 

To not break installations that don't have curl, I modified the Junior.php file to only include the authentication classes in case the curl_init function exists.

Thank you in advance,
Konrad
