### PR TITLE
handle non-existent $params or $id values without throwing an E_NOTICE

### DIFF
--- a/lib/Junior/Serverside/Request.php
+++ b/lib/Junior/Serverside/Request.php
@@ -65,8 +65,12 @@ class Request {
         } else {
             $this->json_rpc = $obj->jsonrpc;
             $this->method = $obj->method;
-            $this->params = $obj->params;
-            $this->id = $obj->id;
+            if (property_exists($obj,'params')) {
+                $this->params = $obj->params;
+            };
+            if (property_exists($obj,'id')) {
+                $this->id = $obj->id;
+            };
         }
     }
 


### PR DESCRIPTION
Implemented checks to handle non-existent $params or $id values without throwing an E_NOTICE. Fixes Issue https://github.com/frankmayer/junior/issues/1
