### PR TITLE
Fixed getting null as result when server returns objects

### DIFF
--- a/src/Junior/Clientside/Response.php
+++ b/src/Junior/Clientside/Response.php
@@ -12,7 +12,13 @@ class Response
     // create a new json rpc response object
     public function __construct($result, $id = null, $error_code = null, $error_message = null)
     {
-        $this->result = is_string($result) ? utf8_decode($result) : $result;
+        if (is_object($result) || is_array($result)) {
+            $this->result = new \ArrayObject($result);
+        } else if (is_string($result)) {
+            $this->result = utf8_decode($result);
+        } else {
+            $this->result = $result;
+        }
         $this->id = $id;
         $this->error_code = $error_code;
         $this->error_message = $error_message;

--- a/src/Junior/Clientside/Response.php
+++ b/src/Junior/Clientside/Response.php
@@ -12,7 +12,7 @@ class Response
     // create a new json rpc response object
     public function __construct($result, $id = null, $error_code = null, $error_message = null)
     {
-        $this->result = utf8_decode($result);
+        $this->result = is_string($result) ? utf8_decode($result) : $result;
         $this->id = $id;
         $this->error_code = $error_code;
         $this->error_message = $error_message;

--- a/src/Junior/Serverside/Request.php
+++ b/src/Junior/Serverside/Request.php
@@ -76,7 +76,14 @@ class Request
             $this->json_rpc = $obj->jsonrpc;
             $this->method = $obj->method;
             if (property_exists($obj,'params')) {
-                $this->params = $obj->params;
+                $this->params = array();
+                foreach ($obj->params as $param) {
+                    if (is_array($param) || is_object($param)) {
+                        array_push($this->params, new \ArrayObject($param));
+                    } else {
+                        array_push($this->params, $param);
+                    }
+                }
             };
             if (property_exists($obj,'id')) {
                 $this->id = $obj->id;


### PR DESCRIPTION
When the response is a object, the utf8_decode returns a null object. According to the spec, the result could be anything sent by the server.
I have added a small check to check whether its a string.
